### PR TITLE
Add company-org-block-auto-indent

### DIFF
--- a/company-org-block.el
+++ b/company-org-block.el
@@ -54,9 +54,9 @@
 	  (const :tag "prompt: ask before entering edit mode" prompt)
 	  (const :tag "auto: automatically enter edit mode" auto)))
 
-(defcustom company-org-block-apply-init-indent t
-  "If t, insert source block by following rule defined in `org-indent-line'.
-If nil, source block will be inserted at the cursor position in a tree."
+(defcustom company-org-block-auto-indent t
+  "If t, automatically indent source block using `org-indent-line'.
+Otherwise, insert block at cursor position."
   :type 'boolean)
 
 (defvar company-org-block--regexp "<\\([^ ]*\\)")
@@ -140,7 +140,7 @@ COMMAND and ARG are sent by company itself."
 #+begin_BEGIN
   |
 #+end_END"
-  (when company-org-block-apply-init-indent
+  (when company-org-block-auto-indent
     (org-indent-line))
   (insert (format "#+begin_%s\n" begin))
   (org-indent-line) ;; pushes to start of indented code-block.

--- a/company-org-block.el
+++ b/company-org-block.el
@@ -56,7 +56,7 @@
 
 (defcustom company-org-block-apply-init-indent t
   "If t, insert source block by following rule defined in `org-indent-line'.
-If non-nil, source block will be inserted at the cursor position in a tree."
+If nil, source block will be inserted at the cursor position in a tree."
   :type 'boolean)
 
 (defvar company-org-block--regexp "<\\([^ ]*\\)")

--- a/company-org-block.el
+++ b/company-org-block.el
@@ -54,6 +54,11 @@
 	  (const :tag "prompt: ask before entering edit mode" prompt)
 	  (const :tag "auto: automatically enter edit mode" auto)))
 
+(defcustom company-org-block-apply-init-indent t
+  "If t, insert source block by following rule defined in `org-indent-line'.
+If non-nil, source block will be inserted at the cursor position in a tree."
+  :type 'boolean)
+
 (defvar company-org-block--regexp "<\\([^ ]*\\)")
 
 (defun company-org-block (command &optional arg &rest _ignored)
@@ -135,7 +140,8 @@ COMMAND and ARG are sent by company itself."
 #+begin_BEGIN
   |
 #+end_END"
-  (org-indent-line)
+  (when company-org-block-apply-init-indent
+    (org-indent-line))
   (insert (format "#+begin_%s\n" begin))
   (org-indent-line) ;; pushes to start of indented code-block.
   (insert (make-string org-edit-src-content-indentation ?\s))


### PR DESCRIPTION
Some users including me may want to not to indent the source block in a tree. So `company-org-block-apply-init-indent` is added to control whether indent the block or not. The default value is `t` which will not break the current behavior of this nice package.